### PR TITLE
fix: reduce context bloat from VM orchestration output

### DIFF
--- a/extensions/vers-vm.ts
+++ b/extensions/vers-vm.ts
@@ -288,8 +288,14 @@ export default function versVmExtension(pi: ExtensionAPI) {
 		async execute() {
 			const vms = await getClient().list();
 			const active = activeVmId ? ` (active: ${activeVmId.slice(0, 12)})` : "";
+			// Compact format: one line per VM instead of full JSON dump
+			const lines = vms.map(v => {
+				const marker = v.vm_id === activeVmId ? " ★" : "";
+				return `  ${v.vm_id.slice(0, 12)} [${v.state}]${marker}  created ${v.created_at}`;
+			});
+			const text = `${vms.length} VM(s)${active}\n${lines.join("\n")}`;
 			return {
-				content: [{ type: "text", text: `${vms.length} VM(s)${active}\n\n${JSON.stringify(vms, null, 2)}` }],
+				content: [{ type: "text", text }],
 				details: { vms },
 			};
 		},
@@ -455,12 +461,15 @@ export default function versVmExtension(pi: ExtensionAPI) {
 			const chunks: Buffer[] = [];
 			let totalBytes = 0;
 
+			const MAX_STREAMING_PREVIEW = 20000; // 20KB for live streaming updates
+			const MAX_FINAL_OUTPUT = 10000;     // 10KB for final result in context
+
 			const handleData = (data: Buffer) => {
 				chunks.push(data);
 				totalBytes += data.length;
 				if (onUpdate) {
 					const text = Buffer.concat(chunks).toString("utf-8");
-					const truncated = text.length > 50000 ? text.slice(-50000) : text;
+					const truncated = text.length > MAX_STREAMING_PREVIEW ? text.slice(-MAX_STREAMING_PREVIEW) : text;
 					onUpdate({ content: [{ type: "text", text: truncated }], details: {} });
 				}
 			};
@@ -472,8 +481,14 @@ export default function versVmExtension(pi: ExtensionAPI) {
 					timeout: effectiveTimeout,
 				});
 
-				const output = Buffer.concat(chunks).toString("utf-8") || "(no output)";
+				let output = Buffer.concat(chunks).toString("utf-8") || "(no output)";
 				const exitCode = result.exitCode ?? 0;
+				const fullLength = output.length;
+
+				// Truncate final output to keep context small — keep the tail which is usually most relevant
+				if (output.length > MAX_FINAL_OUTPUT) {
+					output = `[... truncated ${fullLength - MAX_FINAL_OUTPUT} bytes, showing last ${MAX_FINAL_OUTPUT} bytes ...]\n` + output.slice(-MAX_FINAL_OUTPUT);
+				}
 
 				if (exitCode !== 0) {
 					throw new Error(`${output}\n\nCommand exited with code ${exitCode}`);
@@ -537,10 +552,10 @@ export default function versVmExtension(pi: ExtensionAPI) {
 			let text = result.stdout;
 			const outputLines = text.split("\n").length;
 
-			// Truncate if too large (50KB)
-			if (text.length > 50000) {
-				text = text.slice(0, 50000);
-				text += `\n\n[Output truncated at 50KB. Use offset/limit for large files.]`;
+			// Truncate if too large (20KB)
+			if (text.length > 20000) {
+				text = text.slice(0, 20000);
+				text += `\n\n[Output truncated at 20KB. Use offset/limit for large files.]`;
 			}
 
 			// Add continuation hint


### PR DESCRIPTION
Addresses #2 — context window fills up faster than compaction can run during VM orchestration.

## Changes

### vers-vm.ts
- **Remote bash output**: Final result capped at **10KB** (was 50KB), keeps the tail which is most relevant. Streaming preview reduced to 20KB.
- **`vers_vms`**: Compact one-line-per-VM format instead of full JSON dump. Full data still in `details` for programmatic access.
- **Remote `read`**: Truncation threshold reduced from 50KB to **20KB**.

### vers-swarm.ts
- **`vers_swarm_wait`**: Returns **500-char summaries** per agent instead of dumping full output. Points to `vers_swarm_read` for details. This is the biggest win — previously a 3-agent swarm could dump 100KB+ into context in one shot.
- **`vers_swarm_read`**: Defaults to last **5000 chars** instead of full dump. Pass `tail: 0` to get everything.
- New `formatAgentSummary()` helper for consistent truncated output formatting.

## Context budget impact (rough estimates)

| Tool | Before | After |
|------|--------|-------|
| Remote bash (large output) | ~50KB | ~10KB |
| `vers_vms` (10 VMs) | ~5KB JSON | ~500B |
| `vers_swarm_wait` (3 agents) | ~100KB+ | ~2KB |
| `vers_swarm_read` | unbounded | ~5KB |
| Remote `read` | ~50KB | ~20KB |