### PR TITLE
feat: add Clawdbot extensions and skills

### DIFF
--- a/clawdbot/README.md
+++ b/clawdbot/README.md
@@ -1,0 +1,45 @@
+# Clawdbot Extensions
+
+Clawdbot-compatible versions of the Vers tools.
+
+## Installation
+
+### Plugin (native tools)
+
+Copy `extensions/vers-vm/` to `~/.clawdbot/extensions/vers-vm/` and enable in config:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "vers-vm": { "enabled": true }
+    }
+  }
+}
+```
+
+Then restart the gateway.
+
+### Skills (instruction-based)
+
+Copy `skills/vers-vm/` and `skills/vers-swarm/` to your workspace's `skills/` directory.
+
+## What's Included
+
+### Extensions (native tools)
+
+| Extension | Tools |
+|-----------|-------|
+| `vers-vm` | `vers_vms`, `vers_vm_create`, `vers_vm_delete`, `vers_vm_branch`, `vers_vm_commit`, `vers_vm_restore`, `vers_vm_state`, `vers_vm_ssh_key` |
+
+### Skills (instructions)
+
+| Skill | Description |
+|-------|-------------|
+| `vers-vm` | API reference and workflows for Vers VM management |
+| `vers-swarm` | Agent swarm orchestration patterns across branched VMs |
+
+## Requirements
+
+- `VERS_API_KEY` environment variable set
+- Clawdbot 2026.1.x or later

--- a/clawdbot/extensions/vers-vm/clawdbot.plugin.json
+++ b/clawdbot/extensions/vers-vm/clawdbot.plugin.json
@@ -1,0 +1,21 @@
+{
+  "id": "vers-vm",
+  "name": "Vers VM",
+  "version": "1.0.0",
+  "description": "Vers VM management - create, branch, commit, restore Firecracker VMs",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "baseUrl": {
+        "type": "string",
+        "description": "Vers API base URL"
+      }
+    }
+  },
+  "uiHints": {
+    "baseUrl": {
+      "label": "API Base URL",
+      "placeholder": "https://api.vers.sh/api/v1"
+    }
+  }
+}

--- a/clawdbot/extensions/vers-vm/index.ts
+++ b/clawdbot/extensions/vers-vm/index.ts
@@ -1,0 +1,248 @@
+/**
+ * Vers VM Extension for Clawdbot
+ * 
+ * Provides tools for managing Vers VMs (vers.sh)
+ */
+
+const DEFAULT_BASE_URL = "https://api.vers.sh/api/v1";
+
+export default function versVmPlugin(api: any) {
+  const logger = api.logger || console;
+
+  function getBaseUrl(): string {
+    const cfg = api.getConfig?.()?.plugins?.entries?.["vers-vm"]?.config;
+    return cfg?.baseUrl || process.env.VERS_BASE_URL || DEFAULT_BASE_URL;
+  }
+
+  function getApiKey(): string {
+    return process.env.VERS_API_KEY || "";
+  }
+
+  async function versApi<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const baseUrl = getBaseUrl();
+    const apiKey = getApiKey();
+    
+    if (!apiKey) {
+      throw new Error("VERS_API_KEY environment variable not set");
+    }
+
+    const url = `${baseUrl}${path}`;
+    const res = await fetch(url, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${apiKey}`,
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Vers API ${method} ${path} failed (${res.status}): ${text}`);
+    }
+
+    const ct = res.headers.get("content-type") || "";
+    if (ct.includes("application/json")) {
+      return res.json() as Promise<T>;
+    }
+    return undefined as T;
+  }
+
+  // =========================================================================
+  // Tools
+  // =========================================================================
+
+  api.registerTool({
+    name: "vers_vms",
+    description: "List all Vers VMs. Returns VM IDs, states (running/paused/booting), and creation times.",
+    parameters: { type: "object", properties: {}, required: [] },
+    async execute() {
+      const vms = await versApi<any[]>("GET", "/vms");
+      const summary = vms.map((v: any) => `${v.vm_id.slice(0, 12)} [${v.state}] created ${v.created_at}`).join("\n");
+      return {
+        content: [{ type: "text", text: vms.length === 0 ? "No VMs found." : `${vms.length} VM(s):\n${summary}` }],
+      };
+    },
+  });
+
+  api.registerTool({
+    name: "vers_vm_create",
+    description: "Create a new root Firecracker VM on the Vers platform. Returns the new VM ID.",
+    parameters: {
+      type: "object",
+      properties: {
+        vcpu_count: { type: "number", description: "Number of vCPUs (default: 1)" },
+        mem_size_mib: { type: "number", description: "RAM in MiB (default: 512)" },
+        fs_size_mib: { type: "number", description: "Disk size in MiB (default: 512)" },
+        wait_boot: { type: "boolean", description: "Wait for VM to finish booting (default: false)" },
+      },
+      required: [],
+    },
+    async execute(_id: string, params: any) {
+      const { vcpu_count, mem_size_mib, fs_size_mib, wait_boot } = params;
+      const vmConfig: Record<string, number> = {};
+      if (vcpu_count !== undefined) vmConfig.vcpu_count = vcpu_count;
+      if (mem_size_mib !== undefined) vmConfig.mem_size_mib = mem_size_mib;
+      if (fs_size_mib !== undefined) vmConfig.fs_size_mib = fs_size_mib;
+      
+      const q = wait_boot ? "?wait_boot=true" : "";
+      const result = await versApi<{ vm_id: string }>("POST", `/vm/new_root${q}`, { vm_config: vmConfig });
+      
+      return {
+        content: [{ type: "text", text: `VM created: ${result.vm_id}` }],
+      };
+    },
+  });
+
+  api.registerTool({
+    name: "vers_vm_delete",
+    description: "Delete a Vers VM by ID. This is irreversible.",
+    parameters: {
+      type: "object",
+      properties: {
+        vm_id: { type: "string", description: "VM ID to delete" },
+      },
+      required: ["vm_id"],
+    },
+    async execute(_id: string, params: any) {
+      const { vm_id } = params;
+      await versApi<any>("DELETE", `/vm/${encodeURIComponent(vm_id)}`);
+      return {
+        content: [{ type: "text", text: `VM ${vm_id} deleted.` }],
+      };
+    },
+  });
+
+  api.registerTool({
+    name: "vers_vm_branch",
+    description: "Branch (clone) a VM. Creates a new VM with identical state. Like git branch for VMs.",
+    parameters: {
+      type: "object",
+      properties: {
+        vm_id: { type: "string", description: "VM ID to branch from" },
+      },
+      required: ["vm_id"],
+    },
+    async execute(_id: string, params: any) {
+      const { vm_id } = params;
+      const result = await versApi<{ vm_id: string }>("POST", `/vm/${encodeURIComponent(vm_id)}/branch`);
+      return {
+        content: [{ type: "text", text: `Branched VM ${vm_id.slice(0, 12)} → ${result.vm_id}` }],
+      };
+    },
+  });
+
+  api.registerTool({
+    name: "vers_vm_commit",
+    description: "Commit (snapshot) a VM's current state. Returns a commit ID that can be used to restore later.",
+    parameters: {
+      type: "object",
+      properties: {
+        vm_id: { type: "string", description: "VM ID to commit" },
+        keep_paused: { type: "boolean", description: "Keep VM paused after commit (default: false)" },
+      },
+      required: ["vm_id"],
+    },
+    async execute(_id: string, params: any) {
+      const { vm_id, keep_paused } = params;
+      const q = keep_paused ? "?keep_paused=true" : "";
+      const result = await versApi<{ commit_id: string }>("POST", `/vm/${encodeURIComponent(vm_id)}/commit${q}`);
+      return {
+        content: [{ type: "text", text: `VM ${vm_id.slice(0, 12)} committed: ${result.commit_id}` }],
+      };
+    },
+  });
+
+  api.registerTool({
+    name: "vers_vm_restore",
+    description: "Restore a new VM from a previously created commit. Creates a new VM in the exact state of the commit.",
+    parameters: {
+      type: "object",
+      properties: {
+        commit_id: { type: "string", description: "Commit ID to restore from" },
+      },
+      required: ["commit_id"],
+    },
+    async execute(_id: string, params: any) {
+      const { commit_id } = params;
+      const result = await versApi<{ vm_id: string }>("POST", "/vm/from_commit", { commit_id });
+      return {
+        content: [{ type: "text", text: `Restored from commit ${commit_id.slice(0, 12)} → VM ${result.vm_id}` }],
+      };
+    },
+  });
+
+  api.registerTool({
+    name: "vers_vm_state",
+    description: "Pause or resume a Vers VM. Paused VMs preserve memory state but don't consume compute.",
+    parameters: {
+      type: "object",
+      properties: {
+        vm_id: { type: "string", description: "VM ID to update" },
+        state: { type: "string", enum: ["Paused", "Running"], description: "Target state" },
+      },
+      required: ["vm_id", "state"],
+    },
+    async execute(_id: string, params: any) {
+      const { vm_id, state } = params;
+      await versApi<void>("PATCH", `/vm/${encodeURIComponent(vm_id)}/state`, { state });
+      return {
+        content: [{ type: "text", text: `VM ${vm_id.slice(0, 12)} state set to ${state}.` }],
+      };
+    },
+  });
+
+  api.registerTool({
+    name: "vers_vm_ssh_key",
+    description: "Get SSH credentials for a VM. Returns connection instructions for SSH-over-TLS.",
+    parameters: {
+      type: "object",
+      properties: {
+        vm_id: { type: "string", description: "VM ID to get SSH key for" },
+      },
+      required: ["vm_id"],
+    },
+    async execute(_id: string, params: any) {
+      const { vm_id } = params;
+      const result = await versApi<{ ssh_private_key: string; ssh_port: number }>("GET", `/vm/${encodeURIComponent(vm_id)}/ssh_key`);
+      
+      const keyPreview = result.ssh_private_key.split("\n").slice(0, 2).join("\n");
+      const instructions = `SSH Connection for VM ${vm_id.slice(0, 12)}:
+
+1. Save the key to a file and chmod 600
+2. Connect via SSH-over-TLS:
+   ssh -i <keyfile> -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \\
+     -o ProxyCommand="openssl s_client -connect %h:443 -servername %h -quiet 2>/dev/null" \\
+     root@${vm_id}.vm.vers.sh
+
+Key preview:
+${keyPreview}
+[... key truncated ...]`;
+
+      return {
+        content: [{ type: "text", text: instructions }],
+      };
+    },
+  });
+
+  api.registerTool({
+    name: "vers_vm_branch_commit",
+    description: "Create a new VM by branching directly from a commit ID (instead of a running VM).",
+    parameters: {
+      type: "object",
+      properties: {
+        commit_id: { type: "string", description: "Commit ID to branch from" },
+      },
+      required: ["commit_id"],
+    },
+    async execute(_id: string, params: any) {
+      const { commit_id } = params;
+      const result = await versApi<{ vm_id: string }>("POST", `/vm/branch/by_commit/${encodeURIComponent(commit_id)}`);
+      return {
+        content: [{ type: "text", text: `Branched from commit ${commit_id.slice(0, 12)} → VM ${result.vm_id}` }],
+      };
+    },
+  });
+
+  if (logger.info) logger.info("Vers VM plugin loaded");
+}

--- a/clawdbot/skills/vers-swarm/SKILL.md
+++ b/clawdbot/skills/vers-swarm/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: vers-swarm
+description: Orchestrate agent swarms across Vers VMs - spawn parallel agents on branched VMs for distributed work, parallel exploration, or multi-path problem solving. Use when you need to run multiple agents simultaneously on isolated environments.
+---
+
+# Vers Swarm Orchestration
+
+Spawn and coordinate multiple agents across branched Vers VMs. Each agent runs in an isolated environment branched from a common state.
+
+## Prerequisites
+
+- `VERS_API_KEY` environment variable
+- A committed VM state (commit_id) to branch from
+- For Clawdbot swarms: use `sessions_spawn` for each VM
+
+## Concept
+
+```
+        [Golden Commit]
+              │
+    ┌─────────┼─────────┐
+    ▼         ▼         ▼
+ [VM-A]    [VM-B]    [VM-C]
+ Agent1    Agent2    Agent3
+   │         │         │
+   ▼         ▼         ▼
+ Result1   Result2   Result3
+```
+
+All agents start from identical state, explore independently, report back.
+
+## Workflow
+
+### 1. Prepare Golden State
+
+Create and configure a VM with all needed tools:
+
+```bash
+# Create VM
+VM_ID=$(curl -s -X POST -H "Authorization: Bearer $VERS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"vm_config": {"vcpu_count": 2, "mem_size_mib": 2048, "fs_size_mib": 2048}}' \
+  "https://api.vers.sh/api/v1/vm/new_root?wait_boot=true" | jq -r .vm_id)
+
+# SSH in and install tools (Node, Python, git, etc.)
+# ... setup commands ...
+
+# Commit as golden image
+COMMIT_ID=$(curl -s -X POST -H "Authorization: Bearer $VERS_API_KEY" \
+  https://api.vers.sh/api/v1/vm/$VM_ID/commit | jq -r .commit_id)
+
+echo "Golden commit: $COMMIT_ID"
+```
+
+### 2. Spawn Swarm
+
+Branch N VMs from the golden commit:
+
+```bash
+# Branch from commit (repeat for each agent)
+NEW_VM=$(curl -s -X POST -H "Authorization: Bearer $VERS_API_KEY" \
+  https://api.vers.sh/api/v1/vm/branch/by_commit/$COMMIT_ID | jq -r .vm_id)
+```
+
+### 3. Dispatch Tasks
+
+For Clawdbot, use `sessions_spawn` to create sub-agents that SSH into each VM:
+
+```
+For each VM:
+  1. Get SSH credentials
+  2. Spawn sub-agent with task
+  3. Sub-agent SSHs to VM, executes task
+  4. Report results back
+```
+
+### 4. Collect Results
+
+Wait for all agents to complete, gather outputs.
+
+### 5. Teardown
+
+Delete all swarm VMs when done:
+
+```bash
+curl -s -X DELETE -H "Authorization: Bearer $VERS_API_KEY" \
+  https://api.vers.sh/api/v1/vm/$VM_ID
+```
+
+## Use Cases
+
+### Parallel Code Exploration
+- Branch 3 VMs
+- Agent A: Try approach with library X
+- Agent B: Try approach with library Y  
+- Agent C: Try from-scratch implementation
+- Compare results, pick winner
+
+### Distributed Testing
+- Branch per test suite
+- Run tests in parallel
+- Aggregate results
+
+### Safe Experimentation
+- Branch before risky changes
+- If it breaks, the original is untouched
+- If it works, commit the new state
+
+## Coordination Patterns
+
+### Fan-Out / Fan-In
+1. Coordinator commits baseline
+2. Fan-out: spawn N workers from commit
+3. Workers execute independently
+4. Fan-in: collect results, synthesize
+
+### Checkpoint & Retry
+1. Commit before each major step
+2. If step fails, restore and retry with different approach
+3. Build up chain of successful commits
+
+## Tips
+
+- Keep golden images minimal but complete
+- Commit often — checkpoints are cheap
+- Label your commits (store commit_id → description mapping)
+- Clean up VMs when done to avoid costs
+- VMs branch instantly — the copy-on-write is fast

--- a/clawdbot/skills/vers-vm/SKILL.md
+++ b/clawdbot/skills/vers-vm/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: vers-vm
+description: Manage Vers VMs (vers.sh) - create, branch, commit, restore, pause/resume Firecracker VMs. Use when working with Vers platform, VM orchestration, or when you need isolated execution environments.
+---
+
+# Vers VM Management
+
+Vers provides Firecracker VMs that can be branched like git. Use for isolated environments, parallel exploration, or safe experimentation.
+
+## Prerequisites
+
+- `VERS_API_KEY` environment variable set
+- API endpoint: `https://api.vers.sh/api/v1`
+
+## Quick Reference
+
+### List VMs
+```bash
+curl -s -H "Authorization: Bearer $VERS_API_KEY" \
+  https://api.vers.sh/api/v1/vms | jq .
+```
+
+### Create VM
+```bash
+curl -s -X POST -H "Authorization: Bearer $VERS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"vm_config": {"vcpu_count": 1, "mem_size_mib": 512, "fs_size_mib": 512}}' \
+  https://api.vers.sh/api/v1/vm/new_root | jq .
+```
+
+Add `?wait_boot=true` to wait for VM to be ready.
+
+### Branch VM (clone current state)
+```bash
+curl -s -X POST -H "Authorization: Bearer $VERS_API_KEY" \
+  https://api.vers.sh/api/v1/vm/{vm_id}/branch | jq .
+```
+
+### Commit VM (snapshot)
+```bash
+curl -s -X POST -H "Authorization: Bearer $VERS_API_KEY" \
+  https://api.vers.sh/api/v1/vm/{vm_id}/commit | jq .
+```
+Returns `commit_id` for later restore.
+
+### Restore from Commit
+```bash
+curl -s -X POST -H "Authorization: Bearer $VERS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"commit_id": "COMMIT_ID"}' \
+  https://api.vers.sh/api/v1/vm/from_commit | jq .
+```
+
+### Pause/Resume VM
+```bash
+# Pause
+curl -s -X PATCH -H "Authorization: Bearer $VERS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"state": "Paused"}' \
+  https://api.vers.sh/api/v1/vm/{vm_id}/state
+
+# Resume
+curl -s -X PATCH -H "Authorization: Bearer $VERS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"state": "Running"}' \
+  https://api.vers.sh/api/v1/vm/{vm_id}/state
+```
+
+### Delete VM
+```bash
+curl -s -X DELETE -H "Authorization: Bearer $VERS_API_KEY" \
+  https://api.vers.sh/api/v1/vm/{vm_id}
+```
+
+### Get SSH Credentials
+```bash
+curl -s -H "Authorization: Bearer $VERS_API_KEY" \
+  https://api.vers.sh/api/v1/vm/{vm_id}/ssh_key | jq .
+```
+Returns `ssh_private_key` and `ssh_port` (443).
+
+## SSH Connection
+
+Vers uses SSH-over-TLS on port 443:
+
+```bash
+# Save the key
+curl -s -H "Authorization: Bearer $VERS_API_KEY" \
+  https://api.vers.sh/api/v1/vm/{vm_id}/ssh_key | jq -r .ssh_private_key > /tmp/vers-key.pem
+chmod 600 /tmp/vers-key.pem
+
+# Connect via SSH-over-TLS
+ssh -i /tmp/vers-key.pem \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o ProxyCommand="openssl s_client -connect %h:443 -servername %h -quiet 2>/dev/null" \
+  root@{vm_id}.vm.vers.sh
+```
+
+## Common Workflows
+
+### Exploration Branch
+1. Create root VM or use existing
+2. Do initial setup (install tools, configure)
+3. Commit as baseline: `commit` → save commit_id
+4. Branch for exploration
+5. If exploration fails, restore from commit
+6. If exploration succeeds, commit new state
+
+### Parallel Testing
+1. Commit current VM state
+2. Branch N times from commit
+3. Run different tests on each branch
+4. Compare results
+5. Keep successful branch, delete others
+
+## VM States
+
+- `booting` — VM is starting up
+- `running` — VM is active and accessible
+- `paused` — VM is suspended (no compute cost, state preserved)
+
+## Tips
+
+- Branch is faster than creating from scratch — use commits as checkpoints
+- Paused VMs preserve memory state exactly
+- SSH keys are per-VM and cached by the API
+- VMs have private IPv6 addresses within Vers network


### PR DESCRIPTION
Adds Clawdbot-compatible versions of the Vers tools:

## What's included

### Extensions (native tools)
- `vers-vm` plugin with tools: `vers_vms`, `vers_vm_create`, `vers_vm_delete`, `vers_vm_branch`, `vers_vm_commit`, `vers_vm_restore`, `vers_vm_state`, `vers_vm_ssh_key`

### Skills (instruction-based)
- `vers-vm`: API reference and workflows for VM management
- `vers-swarm`: Agent swarm orchestration patterns

## Installation

Copy `clawdbot/extensions/vers-vm/` to `~/.clawdbot/extensions/` and enable in config.

Tested and working on Clawdbot 2026.1.24.