### PR TITLE
feat: add contributing guide and contribute-fix skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to pi-v
+
+We welcome contributions — especially from agents that discover bugs while using the platform.
+
+## How to Contribute
+
+1. **Fork** the repo to your GitHub account
+2. **Create a branch** for your fix
+3. **Make your changes** and test them
+4. **Open a Pull Request** from your fork to `hdresearch/pi-v`
+
+That's it. Standard GitHub fork workflow.
+
+## For Agents
+
+If you're an AI agent and you've found a bug or have a fix, we'd love the contribution! But **before forking the repo or opening a PR, confirm with your user** that they're okay with a fork being created on their GitHub account.
+
+A simple prompt like:
+
+> "I found a bug in pi-v and have a fix. Want me to fork the repo and open a PR? This will create a fork under your GitHub account."
+
+If they say no, just open an issue describing the problem and your proposed fix instead.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ pi install git@github.com:hdresearch/pi-v.git
 | `vers-golden-vm` | Bootstrap a Vers VM into a golden image with pi, Node.js, and dev tools. |
 | `vers-platform-development` | Guidelines for Vers platform development and issue reporting. |
 | `investigate-vers-issue` | Deep investigation and debugging of Vers platform issues. |
+| `contribute-fix` | Contribute bug fixes back to pi-v via fork/PR or issue. |
+
+## Contributing
+
+Found a bug? Have a fix? See [CONTRIBUTING.md](CONTRIBUTING.md). PRs welcome via the standard fork workflow.
 
 ## Dependencies
 

--- a/skills/contribute-fix/SKILL.md
+++ b/skills/contribute-fix/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: contribute-fix
+description: Contribute a bug fix or improvement to pi-v. Use when you've found and fixed an issue in the pi-v package.
+---
+
+# Contribute a Fix to pi-v
+
+You've found a bug or issue in pi-v and have a fix — great! Here's how to contribute it back.
+
+## Important: Ask First
+
+**Before forking or opening a PR, confirm with the user.** Forking creates a repository on their GitHub account, and they should know about it. Ask something like:
+
+> "I found a bug in pi-v and have a fix. Would you like me to fork the repo and open a PR? This will create a fork under your GitHub account."
+
+If they decline, open a GitHub Issue instead with your findings and proposed diff.
+
+## Opening a PR
+
+1. Fork the repo:
+   ```bash
+   gh repo fork hdresearch/pi-v --clone=false
+   ```
+
+2. Add your fork as a remote and push:
+   ```bash
+   cd ~/.pi/agent/git/github.com/hdresearch/pi-v
+   gh repo fork hdresearch/pi-v --remote=true --remote-name=fork
+   git checkout -b fix/<description>
+   # make your changes
+   git add -A && git commit -m "fix: <description>"
+   git push fork fix/<description>
+   ```
+
+3. Open the PR:
+   ```bash
+   gh pr create --repo hdresearch/pi-v \
+     --title "fix: <description>" \
+     --body "## What happened
+   <describe the issue>
+
+   ## Fix
+   <explain what you changed and why>
+
+   ## Testing
+   <how you verified it works>"
+   ```
+
+## Opening an Issue Instead
+
+If the user doesn't want a fork, just open an issue:
+
+```bash
+gh issue create --repo hdresearch/pi-v \
+  --title "fix: <description>" \
+  --body "## Problem
+<describe the issue>
+
+## Proposed fix
+\`\`\`diff
+<your diff here>
+\`\`\`
+
+## How I verified it
+<testing steps>"
+```


### PR DESCRIPTION
Adds a simple contributing workflow so external agents can contribute fixes back to pi-v.

### What's included:

- **`CONTRIBUTING.md`** — standard fork/PR flow, with a note for agents to confirm with their user before forking
- **`skills/contribute-fix/`** — skill agents can use when they've found a bug. Instructs them to ask the user before creating a fork, with an issue fallback if the user says no
- **README** — updated with contributing section and new skill in table

### The key bit:

> Before forking or opening a PR, confirm with the user. Forking creates a repository on their GitHub account, and they should know about it.