### PR TITLE
fix(lt): lieutenant output reading broken — vers_lt_read always empty

### DIFF
--- a/extensions/vers-lieutenant.ts
+++ b/extensions/vers-lieutenant.ts
@@ -634,6 +634,11 @@ export default function versLieutenantExtension(pi: ExtensionAPI) {
 				lastActivityAt: new Date().toISOString(),
 			};
 
+			// Register handle BEFORE installing event handler — installEventHandler
+			// looks up the handle from rpcHandles, so it must be present first.
+			lieutenants.set(name, lt);
+			rpcHandles.set(name, handle);
+
 			// Install event handler (shared with reconnection path)
 			installEventHandler(lt);
 
@@ -641,9 +646,6 @@ export default function versLieutenantExtension(pi: ExtensionAPI) {
 			if (model) {
 				handle.send({ type: "set_model", provider: "anthropic", modelId: model });
 			}
-
-			lieutenants.set(name, lt);
-			rpcHandles.set(name, handle);
 			await persist();
 			if (ctx) updateWidget(ctx);
 


### PR DESCRIPTION
## Bug

`vers_lt_read` always showed "0 chars" and "(no output yet)" even though the agent on the VM was actively producing output. `vers_lt_status` showed all lieutenants as idle with empty output.

## Root Cause

**Ordering bug in `vers_lt_create`**: `installEventHandler(lt)` was called before `rpcHandles.set(name, handle)`.

`installEventHandler` does `const handle = rpcHandles.get(lt.name)` — but the entry didn't exist yet, so it returned `undefined` and exited early. **No event handler was ever installed for freshly created lieutenants.**

This meant:
- `text_delta` events from the tail process were parsed by the line reader but never dispatched to update `lastOutput`
- `agent_start`/`agent_end` status transitions were also silently dropped
- The agent completed work (tail detected `agent_end`), but the handler wasn't wired up

Notably, the **reconnection path** already had the correct ordering (`rpcHandles.set` before `installEventHandler`), which is why reconnected lieutenants worked but freshly created ones didn't.

## Fix

Move `lieutenants.set()` and `rpcHandles.set()` before `installEventHandler()` in `vers_lt_create`, matching the reconnection path.

One-line diff essentially — the ordering of 3 statements was wrong.