### PR TITLE
fix: use full VM IDs in swarm tool output to prevent registry ID mismatch

### DIFF
--- a/extensions/vers-swarm.ts
+++ b/extensions/vers-swarm.ts
@@ -282,7 +282,7 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 		const lines = [];
 		for (const [id, a] of agents) {
 			const task = a.task ? ` — ${a.task.slice(0, 60)}` : "";
-			lines.push(`  ${id} [${a.status}] (${a.vmId.slice(0, 12)})${task}`);
+			lines.push(`  ${id} [${a.status}] (${a.vmId})${task}`);
 		}
 		return `Swarm (${agents.size} agents):\n${lines.join("\n")}`;
 	}
@@ -415,7 +415,7 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 				});
 
 				if (!rpcReady) {
-					results.push(`${label}: VM ${vmId.slice(0, 12)} booted but pi RPC failed to start`);
+					results.push(`${label}: VM ${vmId} booted but pi RPC failed to start`);
 					await handle.kill();
 					continue;
 				}
@@ -442,7 +442,7 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 
 				agents.set(label, agent);
 				rpcHandles.set(label, handle);
-				results.push(`${label}: VM ${vmId.slice(0, 12)} — ready`);
+				results.push(`${label}: VM ${vmId} — ready`);
 			}
 
 			if (ctx) updateWidget(ctx);
@@ -642,7 +642,7 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 				// Delete VM
 				try {
 					await versApi("DELETE", `/vm/${encodeURIComponent(agent.vmId)}`);
-					results.push(`${id}: VM ${agent.vmId.slice(0, 12)} deleted`);
+					results.push(`${id}: VM ${agent.vmId} deleted`);
 				} catch (err) {
 					results.push(`${id}: failed to delete VM — ${err instanceof Error ? err.message : String(err)}`);
 				}


### PR DESCRIPTION
## What happened

The registry stores wrong VM IDs — the first 12 characters match the actual Vers API UUID, but the rest differs. This breaks all registry-based operations (delete, pause, reconnect).

## Root cause

Tool text outputs in `extensions/vers-swarm.ts` truncate VM IDs to 12 characters via `.slice(0, 12)` in four places:
- `agentSummary()` (line 285) — used by spawn and status tools
- Spawn success message (line 445) — `"agent-1: VM a16d5045-1d9 — ready"`
- Spawn RPC failure message (line 418)
- Teardown success message (line 645)

When the LLM orchestrator later needs to register these VMs in the registry via `registry_register`, it only has 12 characters of the UUID from the text output and hallucinates the remaining characters to form a valid-looking UUID. The `details` field contains full IDs, but LLMs primarily consume the `content[].text` field.

## Fix

Show full VM IDs in all tool `content` text output. Truncation is preserved where appropriate:
- `console.error` log messages (human-facing, not seen by LLM)
- SSH key file names (just need reasonable uniqueness)
- UI widgets (space-constrained, managed separately)

## Testing

Verified that:
- All 4 truncated tool text outputs now use full VM IDs
- Remaining `slice(0, 12)` usages are only in console.error (3) and key file naming (1)
- No other files affected