### PR TITLE
feat: lieutenant completion broadcast — push notifications to orchestrator

### DIFF
--- a/extensions/vers-swarm.ts
+++ b/extensions/vers-swarm.ts
@@ -443,6 +443,15 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 				agents.set(label, agent);
 				rpcHandles.set(label, handle);
 				results.push(`${label}: VM ${vmId.slice(0, 12)} — ready`);
+
+				// Emit lifecycle event — agent-services extension handles registry
+				pi.events.emit("vers:agent_spawned", {
+					vmId,
+					label,
+					role: "worker",
+					address: `${vmId}.vm.vers.sh`,
+					commitId,
+				});
 			}
 
 			if (ctx) updateWidget(ctx);
@@ -638,6 +647,9 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 					try { await handle.kill(); } catch { /* ignore */ }
 					rpcHandles.delete(id);
 				}
+
+				// Emit lifecycle event before deleting VM
+				pi.events.emit("vers:agent_destroyed", { vmId: agent.vmId, label: id });
 
 				// Delete VM
 				try {


### PR DESCRIPTION
## Summary

When a lieutenant finishes a task, the orchestrator now gets a **push notification** instead of relying on polling. No more `vers_lt_read` loops to check if work is done.

## What changed

### Completion broadcast pipeline (`vers-lieutenant.ts`)
- On `agent_end`, the extension now:
  1. **Emits `vers:lt_completed`** on `pi.events` (for other extensions to react)
  2. **Injects a message** into the orchestrator's conversation via `pi.sendMessage()` with `deliverAs: "followUp"` + `triggerTurn: true` — wakes the orchestrator if idle
  3. Includes a concise summary (last ~200 chars of output) + error detection via regex (`/error|failed|exception|fatal/i`)
- Custom **TUI message renderer** registered for `vers:lt_completed` — shows ✅ or ⚠️ with the lieutenant name and summary in a compact format

### Registry refactor (included from stack)
- `registryPost` / `registryDelete` removed from both `vers-lieutenant.ts` and `vers-swarm.ts`
- Replaced with `pi.events.emit()` calls for 4 lifecycle events:
  - `vers:lt_created`, `vers:lt_destroyed`
  - `vers:agent_spawned`, `vers:agent_destroyed`
- Read-only `registryList()` stays for discovery
- Registry writes now handled by the agent-services extension (listener side)

### Swarm lifecycle events (`vers-swarm.ts`)
- Emits `vers:agent_spawned` after each agent is ready
- Emits `vers:agent_destroyed` before VM deletion

## Files changed
- `extensions/vers-lieutenant.ts` — +100/-39 (broadcast logic, renderer, registry→events)
- `extensions/vers-swarm.ts` — +12 (lifecycle events)

## Stack
> ⚠️ Stacked PR — merge in order:
> #12 `feat/vers-lieutenant` → #31 `feat/local-lieutenants` → #32 `fix/remote-lt-startup` → **this PR**