### PR TITLE
refactor: move registry writes to pi.events lifecycle emissions

### DIFF
--- a/extensions/vers-swarm.ts
+++ b/extensions/vers-swarm.ts
@@ -443,6 +443,15 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 				agents.set(label, agent);
 				rpcHandles.set(label, handle);
 				results.push(`${label}: VM ${vmId.slice(0, 12)} — ready`);
+
+				// Emit lifecycle event — agent-services extension handles registry
+				pi.events.emit("vers:agent_spawned", {
+					vmId,
+					label,
+					role: "worker",
+					address: `${vmId}.vm.vers.sh`,
+					commitId,
+				});
 			}
 
 			if (ctx) updateWidget(ctx);
@@ -638,6 +647,9 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 					try { await handle.kill(); } catch { /* ignore */ }
 					rpcHandles.delete(id);
 				}
+
+				// Emit lifecycle event before deleting VM
+				pi.events.emit("vers:agent_destroyed", { vmId: agent.vmId, label: id });
 
 				// Delete VM
 				try {


### PR DESCRIPTION
## Summary

Decouples registry write operations from `vers-swarm.ts` and `vers-lieutenant.ts`. These extensions no longer need to know about the registry API — they just emit lifecycle events, and the agent-services extension handles the actual HTTP calls.

## What changed

### `vers-lieutenant.ts` (-39 lines of registry code)
- **Removed** `registryPost()` and `registryDelete()` helper functions (direct `fetch` calls to registry API)
- **Kept** read-only `registryList()` — still needed for `vers_lt_discover` reconnection
- `vers_lt_create` now emits `vers:lt_created` with `{ vmId, name, role, address, ltRole, commitId, createdAt }`
- `vers_lt_destroy` now emits `vers:lt_destroyed` with `{ vmId, name }`

### `vers-swarm.ts` (+12 lines)
- After agent spawn: emits `vers:agent_spawned` with `{ vmId, label, role, address, commitId }`
- Before VM deletion in teardown: emits `vers:agent_destroyed` with `{ vmId, label }`

## 4 lifecycle events

| Event | Source | Payload |
|-------|--------|---------|
| `vers:lt_created` | lieutenant create | vmId, name, role, address, ltRole, commitId |
| `vers:lt_destroyed` | lieutenant destroy | vmId, name |
| `vers:agent_spawned` | swarm spawn | vmId, label, role, address, commitId |
| `vers:agent_destroyed` | swarm teardown | vmId, label |

## Companion PR
The listener side lives in `hdresearch/vers-agent-services` — the agent-services extension registers `pi.events.on()` handlers that receive these events and make the registry API calls.

## Stack
> ⚠️ Stacked on #32 (`fix/remote-lt-startup`)