### PR TITLE
fix: parallelize reconnection SSH probes on startup

### DIFF
--- a/extensions/vers-swarm.ts
+++ b/extensions/vers-swarm.ts
@@ -105,7 +105,7 @@ export function sshArgs(keyPath: string, vmId: string): string[] {
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "LogLevel=ERROR",
-		"-o", "ConnectTimeout=30",
+		"-o", "ConnectTimeout=10",
 		"-o", "ServerAliveInterval=15",
 		"-o", "ServerAliveCountMax=4",
 		"-o", `ProxyCommand=openssl s_client -connect %h:443 -servername %h -quiet 2>/dev/null`,
@@ -223,7 +223,7 @@ export async function syncPiConfig(keyPath: string, vmId: string): Promise<strin
 				"-o", "StrictHostKeyChecking=no",
 				"-o", "UserKnownHostsFile=/dev/null",
 				"-o", "LogLevel=ERROR",
-				"-o", "ConnectTimeout=30",
+				"-o", "ConnectTimeout=10",
 				"-o", `ProxyCommand=openssl s_client -connect ${vmId}.vm.vers.sh:443 -servername ${vmId}.vm.vers.sh -quiet 2>/dev/null`,
 				localPath,
 				`root@${vmId}.vm.vers.sh:${remotePath}`,
@@ -292,7 +292,7 @@ export async function syncPiConfig(keyPath: string, vmId: string): Promise<strin
 					`-o StrictHostKeyChecking=no`,
 					`-o UserKnownHostsFile=/dev/null`,
 					`-o LogLevel=ERROR`,
-					`-o ConnectTimeout=30`,
+					`-o ConnectTimeout=10`,
 					`-o "ProxyCommand=openssl s_client -connect ${vmId}.vm.vers.sh:443 -servername ${vmId}.vm.vers.sh -quiet 2>/dev/null"`,
 				].join(" ");
 				const args = [
@@ -911,164 +911,164 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 
 		if (swarmEntries.length === 0) return ["No swarm agents found in registry."];
 
-		const results: string[] = [];
-
-		for (const entry of swarmEntries) {
+		// Reconnect all agents in parallel — SSH probes run concurrently
+		// instead of sequentially (N agents × timeout → just 1× timeout)
+		const settled = await Promise.allSettled(swarmEntries.map(async (entry): Promise<string> => {
 			const vmId = entry.id;
 			const label = (entry.metadata?.agentId as string) || entry.name;
 
 			// Skip if already tracked locally
 			if (agents.has(label)) {
-				results.push(`${label}: already connected`);
-				continue;
+				return `${label}: already connected`;
 			}
 
-			try {
-				// Get SSH key for the VM
-				const keyPath = await ensureKeyFile(vmId);
+			// Get SSH key for the VM
+			const keyPath = await ensureKeyFile(vmId);
 
-				// Check if pi-rpc tmux session is still running
-				const check = await sshExec(keyPath, vmId, "tmux has-session -t pi-rpc 2>/dev/null && echo alive || echo dead");
-				if (!check.stdout.includes("alive")) {
-					results.push(`${label}: VM ${vmId.slice(0, 12)} — pi-rpc session not running, skipping`);
-					continue;
-				}
+			// Check if pi-rpc tmux session is still running
+			const check = await sshExec(keyPath, vmId, "tmux has-session -t pi-rpc 2>/dev/null && echo alive || echo dead");
+			if (!check.stdout.includes("alive")) {
+				return `${label}: VM ${vmId.slice(0, 12)} — pi-rpc session not running, skipping`;
+			}
 
-				// Re-establish tail -f on the RPC output (reconnect event stream)
-				// We create a lightweight RpcHandle that just tails and sends — pi is already running
-				let eventHandler: ((event: any) => void) | undefined;
-				let tailChild: ReturnType<typeof spawn> | null = null;
-				let lineBuf = "";
-				let killed = false;
-				let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-				// Start from end — we don't want old events, just new ones
-				let linesProcessed = 0;
+			// Re-establish tail -f on the RPC output (reconnect event stream)
+			// We create a lightweight RpcHandle that just tails and sends — pi is already running
+			let eventHandler: ((event: any) => void) | undefined;
+			let tailChild: ReturnType<typeof spawn> | null = null;
+			let lineBuf = "";
+			let killed = false;
+			let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+			// Start from end — we don't want old events, just new ones
+			let linesProcessed = 0;
 
-				// Count existing lines so we skip them
-				const wcResult = await sshExec(keyPath, vmId, `wc -l < ${RPC_OUT} 2>/dev/null || echo 0`);
-				const existingLines = parseInt(wcResult.stdout.trim(), 10) || 0;
-				linesProcessed = existingLines;
+			// Count existing lines so we skip them
+			const wcResult = await sshExec(keyPath, vmId, `wc -l < ${RPC_OUT} 2>/dev/null || echo 0`);
+			const existingLines = parseInt(wcResult.stdout.trim(), 10) || 0;
+			linesProcessed = existingLines;
 
-				function startTail() {
-					if (killed) return;
-					const args = sshArgs(keyPath, vmId);
-					const startLine = linesProcessed > 0 ? linesProcessed + 1 : 1;
-					tailChild = spawn("ssh", [...args, `tail -f -n +${startLine} ${RPC_OUT}`], {
-						stdio: ["ignore", "pipe", "pipe"],
-					});
-
-					tailChild.stdout!.on("data", (data: Buffer) => {
-						lineBuf += data.toString();
-						const lines = lineBuf.split("\n");
-						lineBuf = lines.pop() || "";
-						for (const line of lines) {
-							linesProcessed++;
-							if (!line.trim()) continue;
-							try {
-								const event = JSON.parse(line);
-								if (eventHandler) eventHandler(event);
-							} catch { /* not JSON */ }
-						}
-					});
-
-					tailChild.stderr!.on("data", (d: Buffer) => {
-						const msg = d.toString().trim();
-						// SSH noise — silenced
-					});
-
-					tailChild.on("close", (code) => {
-						if (killed) return;
-						// reconnect noise — silenced
-						lineBuf = "";
-						reconnectTimer = setTimeout(() => startTail(), 3000);
-					});
-				}
-
-				startTail();
-
-				function send(cmd: object) {
-					if (killed) return;
-					const json = JSON.stringify(cmd) + "\n";
-					const writeChild = spawn("ssh", [...sshArgs(keyPath, vmId), `cat > ${RPC_IN}`], {
-						stdio: ["pipe", "pipe", "pipe"],
-					});
-					writeChild.stdin.write(json);
-					writeChild.stdin.end();
-					writeChild.on("error", (err) => {
-						// send failure — silenced
-					});
-				}
-
-				async function kill() {
-					killed = true;
-					if (reconnectTimer) clearTimeout(reconnectTimer);
-					if (tailChild) {
-						try { tailChild.kill("SIGTERM"); } catch { /* ignore */ }
-						tailChild = null;
-					}
-					try {
-						await sshExec(keyPath, vmId, `
-							tmux kill-session -t pi-rpc 2>/dev/null || true
-							tmux kill-session -t pi-keeper 2>/dev/null || true
-							rm -rf ${RPC_DIR}
-						`);
-					} catch { /* VM might already be gone */ }
-				}
-
-				const handle: RpcHandle = { send, onEvent: (h) => { eventHandler = h; }, kill, vmId };
-
-				// Probe agent state to confirm RPC is alive
-				const probeOk = await new Promise<boolean>((resolve) => {
-					let resolved = false;
-					const timeout = setTimeout(() => { if (!resolved) { resolved = true; resolve(false); } }, 15000);
-					handle.onEvent((event) => {
-						if (!resolved && event.type === "response" && event.command === "get_state") {
-							resolved = true;
-							clearTimeout(timeout);
-							resolve(true);
-						}
-					});
-					handle.send({ id: "reconnect-check", type: "get_state" });
-					// Retry once after 3s
-					setTimeout(() => {
-						if (!resolved) handle.send({ id: "reconnect-check-2", type: "get_state" });
-					}, 3000);
+			function startTail() {
+				if (killed) return;
+				const args = sshArgs(keyPath, vmId);
+				const startLine = linesProcessed > 0 ? linesProcessed + 1 : 1;
+				tailChild = spawn("ssh", [...args, `tail -f -n +${startLine} ${RPC_OUT}`], {
+					stdio: ["ignore", "pipe", "pipe"],
 				});
 
-				if (!probeOk) {
-					killed = true;
-					if (tailChild) { try { tailChild.kill("SIGTERM"); } catch { /* ignore */ } }
-					results.push(`${label}: VM ${vmId.slice(0, 12)} — pi-rpc alive but RPC probe failed, skipping`);
-					continue;
+				tailChild.stdout!.on("data", (data: Buffer) => {
+					lineBuf += data.toString();
+					const lines = lineBuf.split("\n");
+					lineBuf = lines.pop() || "";
+					for (const line of lines) {
+						linesProcessed++;
+						if (!line.trim()) continue;
+						try {
+							const event = JSON.parse(line);
+							if (eventHandler) eventHandler(event);
+						} catch { /* not JSON */ }
+					}
+				});
+
+				tailChild.stderr!.on("data", (d: Buffer) => {
+					const msg = d.toString().trim();
+					// SSH noise — silenced
+				});
+
+				tailChild.on("close", (code) => {
+					if (killed) return;
+					// reconnect noise — silenced
+					lineBuf = "";
+					reconnectTimer = setTimeout(() => startTail(), 3000);
+				});
+			}
+
+			startTail();
+
+			function send(cmd: object) {
+				if (killed) return;
+				const json = JSON.stringify(cmd) + "\n";
+				const writeChild = spawn("ssh", [...sshArgs(keyPath, vmId), `cat > ${RPC_IN}`], {
+					stdio: ["pipe", "pipe", "pipe"],
+				});
+				writeChild.stdin.write(json);
+				writeChild.stdin.end();
+				writeChild.on("error", (err) => {
+					// send failure — silenced
+				});
+			}
+
+			async function kill() {
+				killed = true;
+				if (reconnectTimer) clearTimeout(reconnectTimer);
+				if (tailChild) {
+					try { tailChild.kill("SIGTERM"); } catch { /* ignore */ }
+					tailChild = null;
 				}
+				try {
+					await sshExec(keyPath, vmId, `
+						tmux kill-session -t pi-rpc 2>/dev/null || true
+						tmux kill-session -t pi-keeper 2>/dev/null || true
+						rm -rf ${RPC_DIR}
+					`);
+				} catch { /* VM might already be gone */ }
+			}
 
-				// Set up event handler for ongoing tracking
-				const agent: SwarmAgent = {
-					id: label,
-					vmId,
-					label,
-					status: "idle",
-					lastOutput: "",
-					events: [],
-				};
+			const handle: RpcHandle = { send, onEvent: (h) => { eventHandler = h; }, kill, vmId };
 
+			// Probe agent state to confirm RPC is alive
+			const probeOk = await new Promise<boolean>((resolve) => {
+				let resolved = false;
+				const timeout = setTimeout(() => { if (!resolved) { resolved = true; resolve(false); } }, 15000);
 				handle.onEvent((event) => {
-					agent.events.push(JSON.stringify(event));
-					if (agent.events.length > 200) agent.events.shift();
-					if (event.type === "agent_start") agent.status = "working";
-					else if (event.type === "agent_end") agent.status = "done";
-					else if (event.type === "message_update" && event.assistantMessageEvent?.type === "text_delta") {
-						agent.lastOutput += event.assistantMessageEvent.delta;
+					if (!resolved && event.type === "response" && event.command === "get_state") {
+						resolved = true;
+						clearTimeout(timeout);
+						resolve(true);
 					}
 				});
+				handle.send({ id: "reconnect-check", type: "get_state" });
+				// Retry once after 3s
+				setTimeout(() => {
+					if (!resolved) handle.send({ id: "reconnect-check-2", type: "get_state" });
+				}, 3000);
+			});
 
-				agents.set(label, agent);
-				rpcHandles.set(label, handle);
-				results.push(`${label}: VM ${vmId.slice(0, 12)} — reconnected`);
-			} catch (err) {
-				results.push(`${label}: VM ${vmId.slice(0, 12)} — reconnect failed: ${err instanceof Error ? err.message : String(err)}`);
+			if (!probeOk) {
+				killed = true;
+				if (tailChild) { try { tailChild.kill("SIGTERM"); } catch { /* ignore */ } }
+				return `${label}: VM ${vmId.slice(0, 12)} — pi-rpc alive but RPC probe failed, skipping`;
 			}
-		}
+
+			// Set up event handler for ongoing tracking
+			const agent: SwarmAgent = {
+				id: label,
+				vmId,
+				label,
+				status: "idle",
+				lastOutput: "",
+				events: [],
+			};
+
+			handle.onEvent((event) => {
+				agent.events.push(JSON.stringify(event));
+				if (agent.events.length > 200) agent.events.shift();
+				if (event.type === "agent_start") agent.status = "working";
+				else if (event.type === "agent_end") agent.status = "done";
+				else if (event.type === "message_update" && event.assistantMessageEvent?.type === "text_delta") {
+					agent.lastOutput += event.assistantMessageEvent.delta;
+				}
+			});
+
+			agents.set(label, agent);
+			rpcHandles.set(label, handle);
+			return `${label}: VM ${vmId.slice(0, 12)} — reconnected`;
+		}));
+
+		const results = settled.map((r, i) => {
+			if (r.status === "fulfilled") return r.value;
+			const label = (swarmEntries[i].metadata?.agentId as string) || swarmEntries[i].name;
+			const vmId = swarmEntries[i].id;
+			return `${label}: VM ${vmId.slice(0, 12)} — reconnect failed: ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`;
+		});
 
 		if (ctx) updateWidget(ctx);
 		return results;


### PR DESCRIPTION
## Problem

Swarm reconnection on startup (in `reconnectFromRegistry`) probes each registered VM sequentially via SSH. If there are N dead agents with a 30s SSH timeout each, startup blocks for N×30s.

## Fix

1. **Parallelize probes**: Wrapped the reconnection loop in `Promise.allSettled()` so all SSH probes run concurrently. With 5 dead agents, startup now takes ~10s instead of ~50s.

2. **Reduce SSH timeout**: Changed `ConnectTimeout` from 30s to 10s across all SSH/SCP commands (`sshArgs`, `scpToVm`, rsync). 30s was excessive for probe-style checks.

## Changes

- `extensions/vers-swarm.ts`: Sequential `for...of` loop in `reconnectFromRegistry()` → `Promise.allSettled()` with parallel async callbacks
- `extensions/vers-swarm.ts`: `ConnectTimeout=30` → `ConnectTimeout=10` in all 3 locations