### PR TITLE
fix: update pi repo link to new pi-mono location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-v
 
-A [pi](https://github.com/mariozechner/pi-coding-agent) package for [Vers](https://vers.sh) VM orchestration. Provides extensions for managing Firecracker VMs, orchestrating multi-agent swarms, and running background processes — plus skills for golden image creation, platform development, and issue investigation.
+A [pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) package for [Vers](https://vers.sh) VM orchestration. Provides extensions for managing Firecracker VMs, orchestrating multi-agent swarms, and running background processes — plus skills for golden image creation, platform development, and issue investigation.
 
 ## Install
 


### PR DESCRIPTION
The pi coding agent repo moved from `github.com/mariozechner/pi-coding-agent` to `github.com/badlogic/pi-mono/tree/main/packages/coding-agent`.

This PR updates the README link to point to the new location.

**Note:** The npm package name (`@mariozechner/pi-coding-agent`) has **not** changed, so all import statements, `npm install` commands, and type imports throughout the codebase remain correct as-is. Only the GitHub repository link in the README needed updating.