### PR TITLE
fix: return full VM IDs in tool output so cross-tool workflows work

### DIFF
--- a/extensions/vers-swarm.ts
+++ b/extensions/vers-swarm.ts
@@ -500,7 +500,7 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 		const lines = [];
 		for (const [id, a] of agents) {
 			const task = a.task ? ` — ${a.task.slice(0, 60)}` : "";
-			lines.push(`  ${id} [${a.status}] (${a.vmId.slice(0, 12)})${task}`);
+			lines.push(`  ${id} [${a.status}] (${a.vmId})${task}`);
 		}
 		return `Swarm (${agents.size} agents):\n${lines.join("\n")}`;
 	}
@@ -643,7 +643,7 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 				});
 
 				if (!rpcReady) {
-					results.push(`${label}: VM ${vmId.slice(0, 12)} booted but pi RPC failed to start`);
+					results.push(`${label}: VM ${vmId} booted but pi RPC failed to start`);
 					await handle.kill();
 					continue;
 				}
@@ -681,7 +681,7 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 					metadata: { agentId: label, commitId, parentSession: true },
 				});
 
-				results.push(`${label}: VM ${vmId.slice(0, 12)} — ready`);
+				results.push(`${label}: VM ${vmId} — ready`);
 			}
 
 			if (ctx) updateWidget(ctx);
@@ -884,7 +884,7 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 				// Delete VM
 				try {
 					await versApi("DELETE", `/vm/${encodeURIComponent(agent.vmId)}`);
-					results.push(`${id}: VM ${agent.vmId.slice(0, 12)} deleted`);
+					results.push(`${id}: VM ${agent.vmId} deleted`);
 				} catch (err) {
 					results.push(`${id}: failed to delete VM — ${err instanceof Error ? err.message : String(err)}`);
 				}
@@ -930,7 +930,7 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 				// Check if pi-rpc tmux session is still running
 				const check = await sshExec(keyPath, vmId, "tmux has-session -t pi-rpc 2>/dev/null && echo alive || echo dead");
 				if (!check.stdout.includes("alive")) {
-					results.push(`${label}: VM ${vmId.slice(0, 12)} — pi-rpc session not running, skipping`);
+					results.push(`${label}: VM ${vmId} — pi-rpc session not running, skipping`);
 					continue;
 				}
 
@@ -1038,7 +1038,7 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 				if (!probeOk) {
 					killed = true;
 					if (tailChild) { try { tailChild.kill("SIGTERM"); } catch { /* ignore */ } }
-					results.push(`${label}: VM ${vmId.slice(0, 12)} — pi-rpc alive but RPC probe failed, skipping`);
+					results.push(`${label}: VM ${vmId} — pi-rpc alive but RPC probe failed, skipping`);
 					continue;
 				}
 
@@ -1064,9 +1064,9 @@ export default function versSwarmExtension(pi: ExtensionAPI) {
 
 				agents.set(label, agent);
 				rpcHandles.set(label, handle);
-				results.push(`${label}: VM ${vmId.slice(0, 12)} — reconnected`);
+				results.push(`${label}: VM ${vmId} — reconnected`);
 			} catch (err) {
-				results.push(`${label}: VM ${vmId.slice(0, 12)} — reconnect failed: ${err instanceof Error ? err.message : String(err)}`);
+				results.push(`${label}: VM ${vmId} — reconnect failed: ${err instanceof Error ? err.message : String(err)}`);
 			}
 		}
 

--- a/extensions/vers-vm.ts
+++ b/extensions/vers-vm.ts
@@ -409,7 +409,7 @@ export default function versVmExtension(pi: ExtensionAPI) {
 		parameters: Type.Object({}),
 		async execute() {
 			const vms = await getClient().list();
-			const active = activeVmId ? ` (active: ${activeVmId.slice(0, 12)})` : "";
+			const active = activeVmId ? ` (active: ${activeVmId})` : "";
 			return {
 				content: [{ type: "text", text: `${vms.length} VM(s)${active}\n\n${JSON.stringify(vms, null, 2)}` }],
 				details: { vms },


### PR DESCRIPTION
Fixes #46

## Problem
`vers_vms` truncated VM IDs (e.g. `287a54a6-65c`) in tool output text, but `vers_vm_delete` and other tools need full UUIDs. This broke cross-tool workflows — you couldn't delete VMs discovered via `vers_vms`.

## Fix
Stop truncating VM IDs in tool output strings (`.slice(0, 12)` → full UUID). The truncation is preserved in human-facing UI only (status bar, select menus).

## Changes
- `extensions/vers-vm.ts`: Full UUID in `vers_vms` active VM indicator
- `extensions/vers-swarm.ts`: Full UUIDs in all swarm result/summary strings

No new abstractions, no resolution logic — just make the data correct.