### PR TITLE
fix: vers_vm_use first connection always fails

### DIFF
--- a/extensions/vers-vm.ts
+++ b/extensions/vers-vm.ts
@@ -229,12 +229,16 @@ class VersClient {
 			let stderr = "";
 			if (child.stderr) child.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
 
+			const markActive = () => {
+				child.unref();
+				this.masterActive.add(vmId);
+			};
+
 			// The master process stays alive in the background.
 			// We wait briefly to detect immediate failures (bad key, unreachable, etc.)
 			const timer = setTimeout(() => {
 				// Still running after 5s → master is up
-				child.unref();
-				this.masterActive.add(vmId);
+				markActive();
 				resolve();
 			}, 5000);
 
@@ -245,11 +249,26 @@ class VersClient {
 
 			child.on("close", (code) => {
 				clearTimeout(timer);
-				if (!this.masterActive.has(vmId)) {
-					// Exited before we confirmed it was up — failure
-					reject(new Error(`SSH master exited (code ${code}): ${stderr.trim() || "unknown error"}`));
+				if (this.masterActive.has(vmId)) {
+					// Already marked active, the master was shut down externally — that's fine
+					return;
 				}
-				// If already marked active, the master was shut down externally — that's fine
+				// With ControlPersist=yes, SSH forks a background daemon to maintain the
+				// control socket and the foreground process exits with code 0. Verify the
+				// socket is actually alive via `ssh -O check` before treating exit as failure.
+				if (code === 0) {
+					execFile("ssh", ["-O", "check", ...args], { timeout: 5000 }, (err) => {
+						if (!err) {
+							// Control socket is alive — master established via ControlPersist
+							markActive();
+							resolve();
+						} else {
+							reject(new Error(`SSH master exited (code ${code}): ${stderr.trim() || "unknown error"}`));
+						}
+					});
+					return;
+				}
+				reject(new Error(`SSH master exited (code ${code}): ${stderr.trim() || "unknown error"}`));
 			});
 		});
 	}


### PR DESCRIPTION
## Problem

`vers_vm_use` always fails on the first call with:
```
SSH master exited (code 0): unknown error
```
A second call always succeeds.

## Root Cause

The `openMaster` method spawns SSH with `ControlMaster=yes` and `ControlPersist=yes`. With `ControlPersist=yes`, SSH:

1. Establishes the connection and creates the control socket
2. Forks a background daemon to maintain the socket
3. The foreground `ssh` process exits with code 0

The previous code used a 5-second timer to detect if the process was "still running" as a proxy for success. But with `ControlPersist`, the foreground process exits with code 0 *before* the timer fires. The `close` handler then saw that `masterActive` wasn't set yet and rejected — even though the control socket was alive and working.

On the second call, the control socket from the first ("failed") call was still alive (maintained by the ControlPersist daemon), so the connection would succeed.

## Fix

When the SSH process exits with code 0 before the timer, verify the control socket is actually alive using `ssh -O check` before treating it as a failure. If the socket check passes, mark the master as active and resolve successfully.

This handles the `ControlPersist` fork-and-exit behavior correctly instead of relying solely on the process staying alive for 5 seconds.