### PR TITLE
fix: add 5s timeout to registry fetch calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.claude/

--- a/extensions/vers-lieutenant.ts
+++ b/extensions/vers-lieutenant.ts
@@ -143,6 +143,7 @@ async function registryPost(entry: { id: string; name: string; role: string; add
 			method: "POST",
 			headers: { "Content-Type": "application/json", "Authorization": `Bearer ${authToken}` },
 			body: JSON.stringify(entry),
+			signal: AbortSignal.timeout(5000),
 		});
 	} catch { /* best effort */ }
 }
@@ -155,6 +156,7 @@ async function registryDelete(vmId: string): Promise<void> {
 		await fetch(`${infraUrl}/registry/vms/${encodeURIComponent(vmId)}`, {
 			method: "DELETE",
 			headers: { "Authorization": `Bearer ${authToken}` },
+			signal: AbortSignal.timeout(5000),
 		});
 	} catch { /* best effort */ }
 }
@@ -167,6 +169,7 @@ async function registryList(): Promise<any[]> {
 		const res = await fetch(`${infraUrl}/registry/vms`, {
 			method: "GET",
 			headers: { "Authorization": `Bearer ${authToken}` },
+			signal: AbortSignal.timeout(5000),
 		});
 		if (!res.ok) return [];
 		const data = await res.json() as any;

--- a/extensions/vers-swarm.ts
+++ b/extensions/vers-swarm.ts
@@ -156,6 +156,7 @@ async function registryPost(entry: RegistryEntry): Promise<void> {
 				"Authorization": `Bearer ${authToken}`,
 			},
 			body: JSON.stringify(entry),
+			signal: AbortSignal.timeout(5000),
 		});
 	} catch (err) {
 		console.warn(`[vers-swarm] registry post failed for ${entry.name}: ${err instanceof Error ? err.message : String(err)}`);
@@ -172,6 +173,7 @@ async function registryDelete(vmId: string): Promise<void> {
 			headers: {
 				"Authorization": `Bearer ${authToken}`,
 			},
+			signal: AbortSignal.timeout(5000),
 		});
 	} catch { /* best effort */ }
 }
@@ -186,6 +188,7 @@ async function registryList(): Promise<RegistryEntry[]> {
 			headers: {
 				"Authorization": `Bearer ${authToken}`,
 			},
+			signal: AbortSignal.timeout(5000),
 		});
 		if (!res.ok) return [];
 		const data = await res.json() as { vms?: RegistryEntry[] } | RegistryEntry[];


### PR DESCRIPTION
Adds `AbortSignal.timeout(5000)` to all registry POST/DELETE/GET calls in `vers-lieutenant.ts` and `vers-swarm.ts`.

**Problem:** When the infra VM is down or unreachable, registry calls hang indefinitely, causing tool calls like `registry_list` and `registry_discover` to timeout at the SSH/tool level instead of failing gracefully.

**Fix:** 5-second abort signals on all 6 registry fetch calls. These are best-effort calls anyway (wrapped in try/catch), so a fast timeout is appropriate.