### PR TITLE
Remove vers-lieutenant from default extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "@hdresearch/pi-v",
   "version": "0.2.0",
-  "description": "Vers VM management — for pi (extensions) and Claude Code (MCP server)",
-  "keywords": ["pi-package", "mcp", "vers"],
+  "description": "Vers VM management \u2014 for pi (extensions) and Claude Code (MCP server)",
+  "keywords": [
+    "pi-package",
+    "mcp",
+    "vers"
+  ],
   "license": "MIT",
   "type": "module",
   "repository": {
@@ -48,7 +52,6 @@
     "extensions": [
       "./extensions/background-process.ts",
       "./extensions/plan-mode/index.ts",
-      "./extensions/vers-lieutenant.ts",
       "./extensions/vers-vm.ts",
       "./extensions/vers-vm-copy.ts"
     ],


### PR DESCRIPTION
The lieutenant extension orchestrates multi-VM workflows and can autonomously spawn large numbers of VMs. During testing it created 49 VMs in rapid succession.

Removed from the default `pi.extensions` list in package.json. The file remains in the repo for explicit opt-in use.

Remaining default extensions:
- `background-process.ts` — manage background processes
- `plan-mode/index.ts` — plan mode toggle
- `vers-vm.ts` — core VM tools (list, create, delete, branch, commit, restore, use/local)
- `vers-vm-copy.ts` — copy files to/from VMs